### PR TITLE
upgrade php-http/httplug to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
-
+    - 7.2
+    - 7.3
 env:
     global:
         - TEST_COMMAND="composer test"
@@ -25,10 +23,8 @@ matrix:
         - php: hhvm
     fast_finish: true
     include:
-        - php: 5.5
+        - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: hhvm
-          dist: trusty
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 
 ## Unreleased
+
+### Added
+
+- Support for HTTPlug 2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@
 ### Added
 
 - Support for HTTPlug 2.0.
+
+### Removed
+
+- Support for PHP <7.1

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/discovery": "^1.0",
         "zendframework/zend-http": "^2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,15 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
-        "php-http/httplug": "^1.0 || ^2.0",
+        "php": "^7.1",
+        "php-http/httplug": "^2.0",
         "php-http/discovery": "^1.0",
         "zendframework/zend-http": "^2.3"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^0.6"
+        "ext-curl": "*",
+        "phpunit/phpunit": "^7.4",
+        "php-http/client-integration-tests": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +36,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml"
+        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
     },
     "extra": {
         "branch-alias": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Http\Client as ZendClient;
 use Zend\Http\Exception\RuntimeException;
 use Zend\Http\Header\GenericHeader;
@@ -30,7 +31,7 @@ class Client implements HttpClient
     /**
      * {@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         $request = $this->sanitizeRequest($request);
         $headers = new Headers();

--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client implements HttpClient
      *
      * @param RequestInterface $request
      *
-     * @return RequestInterface|static
+     * @return RequestInterface
      */
     private function sanitizeWithTrace(RequestInterface $request)
     {
@@ -111,7 +111,7 @@ class Client implements HttpClient
      *
      * @param RequestInterface $request
      *
-     * @return RequestInterface|static
+     * @return RequestInterface
      */
     private function sanitizeWithCurl(RequestInterface $request)
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #5
| License         | MIT


#### What's in this PR?

This PR is about upgrading php-http/httplug to version 2.0 and removal of php < 7.1


#### Why?

many libraries depend on version 2.0 of php-http/httplug, so this PR will fix the situation when a lib needs version 2.0 but can not be used because zend-adapter requires 1.0


#### Checklist

- [ x] Updated CHANGELOG.md
